### PR TITLE
fix: allow private resources during aapt2 build

### DIFF
--- a/tools/aapt2/link/ReferenceLinker.cpp
+++ b/tools/aapt2/link/ReferenceLinker.cpp
@@ -299,8 +299,9 @@ const SymbolTable::Symbol* ReferenceLinker::ResolveSymbolCheckVisibility(const R
   }
 
   if (!IsSymbolVisible(*symbol, reference, callsite)) {
-    if (out_error) *out_error = "is private";
-    return nullptr;
+    // if (out_error) *out_error = "is private";
+    // Apktool
+    // return nullptr;
   }
   return symbol;
 }


### PR DESCRIPTION
Folks are complaining that rebuilding an application is too strict with Apktool and to a point - I agree. Tool authors for simple security operations shouldn't have to "fix" an application from build-time errors that were not build time errors when it was built.